### PR TITLE
Increase repository scan depth

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "git.repositoryScanMaxDepth": 2,
     "cucumber.features": [       
         "redcap_cypress/redcap_rsvc/Feature Tests/**/*.feature", //These are the RSVC features
         "redcap_cypress/cypress/features/*.feature" //Standard feature folder


### PR DESCRIPTION
@aldefouw, this allows VS Code's git view to automatically detect `redcap_rsvc` so developers don't have to add it manually (the default scan depth is 1, but we need it to be 2).  Let me know if you have any questions.