### PR TITLE
Move redcap source to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,17 @@ To test against a different version of REDCap, simply run `./download_redcap.sh`
 ./run.sh
 ```
 
+### Update The REDCap Test Environment:
+
+The following should be run periodically to ensure your local environment includes the latest changes.
+
+```
+./update.sh
+```
+
 ### Contribute to Feature Tests:
 
-1. Create your own fork of redcap_rsvc that is based upon https://github.com/aldefouw/redcap_rsvc
+1. Create your own fork of redcap_rsvc that is based upon https://github.com/4bbakers/redcap_rsvc
 
 2. Configure the cloned redcap_rsvc repository as needed to match your own Fork.
 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# The following line is important to ensure this script stops if this repo or submodules have oustanding changes that would prevent a git pull.
+set -e
+
+getUpdateScriptInfo () {
+  ls -l update.sh
+}
+
+oldUpdateScriptInfo=`getUpdateScriptInfo`
+
+git checkout main > /dev/null
+git pull --recurse-submodules
+
+if [ "$oldUpdateScriptInfo" != "`getUpdateScriptInfo`" ]; then
+    echo A changed to update.sh was detected.  Restarting this script...
+    ./update.sh
+    exit
+fi
+
+cd redcap_cypress/redcap_rsvc
+git fetch https://github.com/4bbakers/redcap_rsvc staging
+rsvcBranchName=`git rev-parse --abbrev-ref HEAD`
+if [ "$rsvcBranchName" = "staging" ] || [ "$rsvcBranchName" = "main" ]; then
+    # Developers shouldn't be working directly these branches.
+    # This may be an initial run before any development has started.
+    # Regardless, just checkout the latest
+    git -c advice.detachedHead=false checkout FETCH_HEAD > /dev/null
+else
+    commitsBehindStaging=`git log --oneline ..FETCH_HEAD | wc -l`
+    if [ $commitsBehindStaging != 0 ]; then
+        echo
+        echo Please merge the latest from the 'staging' branch into your redcap_rsvc branch.
+        echo This is not performed automatically to avoid interfering with any active development. 
+        exit
+    fi
+fi
+cd ../..
+
+cd redcap_docker
+docker compose down # This ensures a running container is restarted, which can fix various docker issues.
+docker compose up -d --build # This ensures the container is rebuilt to include any Dockerfile changes, other updates, or fix various issues.


### PR DESCRIPTION
@aldefouw, this is fairly high priority, as it will save Adam L & Ellis a ton of time.  I believe this is a robust solution.  It depends on https://github.com/aldefouw/redcap_docker/pull/4.  It also adds `update.sh`, which means this will hopefully be the last time I have to walk Adam L, Ellis, Baker, or others through routine updates to redcap_cypress_docker, redcap_cypress, or redcap_docker.