### PR TITLE
Prevent update script failing on first run; detect ARM(64) host machine

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -73,6 +73,10 @@ if [ $commitsBehindMain != 0 ]; then
     echo Please either checkout the main branch for redcap_docker, or merge it into your working branch.
     exit
 fi
+# Detect ARM architectures to alter default platorm for redcap_docker build
+if [[ "$(uname -m)" =~ ^(arm64|ARM64|aarch64)$ ]]; then
+    export PLATFORM=linux/arm64
+fi
 docker compose --profile external-storage --profile sftp down # This ensures a running container is restarted, which can fix various docker issues.
 docker compose up -d --build --remove-orphans # This ensures the container is rebuilt to include any Dockerfile changes, other updates, or fix various issues.
 

--- a/update.sh
+++ b/update.sh
@@ -58,7 +58,7 @@ if [ $commitsBehindMaster != 0 ]; then
 fi
 
 # Adam Lewis had an instance where cypress started throwing confusing errors on every feature which was resolved by the following steps:
-rm node_modules -r
+[ -f "node_modules" ] && rm node_modules -r
 npm cache clean --force
 npm install --no-fund --no-audit
 cd ..


### PR DESCRIPTION
# Pre-flight Checklist
- [x] Have all lines in this PR been reviewed & optimized by a human with appropriate coding skills? 
- [x] Are all the features in this PR tested by a human? 
- [x] Have other features this PR touches also been tested by a human?
- [x] Has the code been formatted for consistency and readability?
~~- [ ] Did you also update related documentation and tooling, such as .readme or tests?~~

# Overview
<!--Provide a summary  of this pr. Is this a new module? A new feature? a bug fix? a code reformat?-->
b174c0564808ee3d7af3f45ac8e3f545120d6fc7: `update.sh` was failing at the `rm node_modules -r` step because the directory didn't exist! This prevents that.

e2707473ae6a55c5deaeb41273d4424e7ee7b89c: Since I'm on an ARM-based mac, `redcap_docker-app-1` failed to build due to its `platform` spec. I'll make a corresponding PR to the `redcap_docker` repo to adjust the `docker-compose.yml`.

# Context
<!--Provide a URL to a Jira, Pivotal Tracker story, or Assembla ticket. If those are not appropriate, provide the requirements this PR addresses.-->

# Screenshots
<!--Include screenshots of new pages or features to help other developers understand the features and markup.-->
