### PR TITLE
Removed PLATFORM env setting since removing the platform from docker-compose.yml allows it to be automatically detected instead

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -51,9 +51,6 @@ fi
 awk '{ gsub(/"redcap_version": ".*",/, "\"redcap_version\": \"'$redcapVersion'\","); print }' redcap_cypress/cypress.env.json > awk-temp && mv awk-temp redcap_cypress/cypress.env.json
 
 cd redcap_docker
-if [[ "$(uname -m)" =~ ^(arm64|ARM64|aarch64)$ ]]; then
-    export PLATFORM=linux/arm64
-fi
 docker compose up -d
 cd ..
 

--- a/update.sh
+++ b/update.sh
@@ -73,10 +73,7 @@ if [ $commitsBehindMain != 0 ]; then
     echo Please either checkout the main branch for redcap_docker, or merge it into your working branch.
     exit
 fi
-# Detect ARM architectures to alter default platorm for redcap_docker build
-if [[ "$(uname -m)" =~ ^(arm64|ARM64|aarch64)$ ]]; then
-    export PLATFORM=linux/arm64
-fi
+
 docker compose --profile external-storage --profile sftp down # This ensures a running container is restarted, which can fix various docker issues.
 docker compose up -d --build --remove-orphans # This ensures the container is rebuilt to include any Dockerfile changes, other updates, or fix various issues.
 


### PR DESCRIPTION
@ChemiKyle, I believe this effectively undoes your two recent PLATFORM changes in favor of removing platform from `docker-compose.yml`...assuming that also works for you.  What do you think?